### PR TITLE
Use PathName.isFile to check if file exists

### DIFF
--- a/Require.sc
+++ b/Require.sc
@@ -101,7 +101,7 @@ Require {
 		var paths, results, caller;
 		var relativePath = thisProcess.nowExecutingPath ? "~";
 		relativePath = relativePath.asString;
-		if (relativePath.isFile) {
+		if (PathName(relativePath).isFile) {
 			relativePath = relativePath.dirname;
 		};
 


### PR DESCRIPTION
isFile is only available as a string method if wslib is installed.